### PR TITLE
Update crap4java to 0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Use the Gradle wrapper:
 ./gradlew renderAgents
 ```
 
-`./gradlew crap4javaCheck` runs the shared `media.barney.crap4java` `0.1.1`
+`./gradlew crap4javaCheck` runs the shared `media.barney.crap4java` `0.1.2`
 gate against the repository's production Java sources. `./gradlew qualityGate`
 is the repo-local convenience entrypoint that runs `check` plus
 `crap4javaCheck`.

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'jacoco'
-    id 'media.barney.crap4java' version '0.1.1'
+    id 'media.barney.crap4java' version '0.1.2'
     id 'org.springframework.boot' version '3.5.13'
 }
 


### PR DESCRIPTION
## Summary
- update the shared `media.barney.crap4java` Gradle plugin from `0.1.1` to `0.1.2`
- refresh the README to document the new gate version

## Verification
- local: `./gradlew.bat --refresh-dependencies qualityGate` against a locally published `0.1.2`
- CI: rely on this PR's `Crap4Java Gate` workflow to resolve the released `0.1.2` from GitHub Packages