### PR TITLE
10 Resolve unresolved Copilot review threads

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   gradle-check:

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,19 +1,23 @@
 pluginManagement {
-    def githubPackagesUserProvider = providers.gradleProperty('gpr.user')
-        .orElse(providers.environmentVariable('GITHUB_ACTOR'))
-        .orElse('fabian-barney')
-    def githubPackagesTokenProvider = providers.gradleProperty('gpr.key')
-        .orElse(providers.environmentVariable('GITHUB_TOKEN'))
-        .orElse(providers.environmentVariable('GH_TOKEN'))
+    def nonBlankValue = { String value ->
+        def trimmed = value?.trim()
+        trimmed ? trimmed : null
+    }
+    def githubPackagesUser = nonBlankValue(providers.gradleProperty('gpr.user').orNull)
+        ?: nonBlankValue(providers.environmentVariable('GITHUB_ACTOR').orNull)
+        ?: 'fabian-barney'
+    def githubPackagesToken = nonBlankValue(providers.gradleProperty('gpr.key').orNull)
+        ?: nonBlankValue(providers.environmentVariable('GITHUB_TOKEN').orNull)
+        ?: nonBlankValue(providers.environmentVariable('GH_TOKEN').orNull)
 
     repositories {
         mavenLocal()
-        if (githubPackagesTokenProvider.isPresent()) {
+        if (githubPackagesToken != null) {
             maven {
                 url = uri('https://maven.pkg.github.com/fabian-barney/crap4java')
                 credentials {
-                    username = githubPackagesUserProvider.get()
-                    password = githubPackagesTokenProvider.get()
+                    username = githubPackagesUser
+                    password = githubPackagesToken
                 }
             }
         }


### PR DESCRIPTION
Closes #10

## Implementation Summary
- Scope: resolve the still-valid unresolved review findings left on merged PRs and close stale unresolved threads that are already fixed on `main`
- Key changes:
  - add `packages: read` to the shared workflow permissions so both jobs can read the private GitHub Packages plugin
  - trim and ignore blank GitHub Packages credential values in `settings.gradle` so blank `GITHUB_TOKEN` values fall through to a non-blank fallback token instead of configuring empty-password auth
- Non-goals:
  - broader build or workflow refactors unrelated to the unresolved review findings

## Review Focus
- Generated/copied files and standard imports that can be skimmed:
  - none
- Non-obvious code paths and rationale:
  - `settings.gradle` now resolves package credentials eagerly to plain strings so blank values can be normalized before repository configuration in `pluginManagement`

## Validation
- Tests executed:
  - not completed locally; `./gradlew.bat test` was attempted with blank `GITHUB_TOKEN` and non-blank `GH_TOKEN`, but the private `media.barney.crap4java` Gradle plugin could not be resolved from the current local credentials before project tests started
- Manual checks:
  - inspected the resulting workflow permissions and credential fallback logic against the unresolved review findings
- Residual risks:
  - workflow permission coverage will be confirmed by CI on this PR
