### PR TITLE
Adopt crap-java 0.2.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Run Gradle check
         run: ./gradlew check
 
-  crap4java-gate:
-    name: Crap4Java Gate
+  crap-java-gate:
+    name: crap-java Gate
     runs-on: ubuntu-latest
     env:
       GITHUB_ACTOR: ${{ github.actor }}
@@ -55,5 +55,5 @@ jobs:
       - name: Ensure Gradle wrapper is executable
         run: chmod +x ./gradlew
 
-      - name: Run crap4java gate
-        run: ./gradlew crap4javaCheck
+      - name: Run crap-java gate
+        run: ./gradlew crap-java-check

--- a/README.md
+++ b/README.md
@@ -51,17 +51,17 @@ Use the Gradle wrapper:
 
 ```bash
 ./gradlew check
-./gradlew crap4javaCheck
+./gradlew crap-java-check
 ./gradlew qualityGate
 ./gradlew renderAgents
 ```
 
-`./gradlew crap4javaCheck` runs the shared `media.barney.crap4java` `0.1.2`
+`./gradlew crap-java-check` runs the shared `media.barney.crap-java` `0.2.0`
 gate against the repository's production Java sources. `./gradlew qualityGate`
 is the repo-local convenience entrypoint that runs `check` plus
-`crap4javaCheck`.
+`crap-java-check`.
 
-Gradle resolves the shared `crap4java` plugin from GitHub Packages. Configure
+Gradle resolves the shared `crap-java` plugin from GitHub Packages. Configure
 either:
 
 - `gpr.user` and `gpr.key` in `~/.gradle/gradle.properties`
@@ -69,7 +69,7 @@ either:
 - `GITHUB_ACTOR` with `GH_TOKEN`
 
 For local development, the build also checks `mavenLocal()` first so a freshly
-published local copy of `media.barney.crap4java` is picked up before GitHub
+published local copy of `media.barney.crap-java` is picked up before GitHub
 Packages.
 
 Renderer output artifacts from `./gradlew renderAgents` are written under `build/rendered/`:

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'jacoco'
-    id 'media.barney.crap4java' version '0.1.2'
+    id 'media.barney.crap-java' version '0.2.0'
     id 'org.springframework.boot' version '3.5.13'
 }
 
@@ -75,7 +75,7 @@ tasks.named('jacocoTestReport') {
 tasks.register('qualityGate') {
     group = 'verification'
     description = 'Run the repository quality gate tasks.'
-    dependsOn(tasks.named('check'), tasks.named('crap4javaCheck'))
+    dependsOn(tasks.named('check'), tasks.named('crap-java-check'))
 }
 
 tasks.named('check') {

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,11 +10,19 @@ pluginManagement {
         ?: nonBlankValue(providers.environmentVariable('GITHUB_TOKEN').orNull)
         ?: nonBlankValue(providers.environmentVariable('GH_TOKEN').orNull)
 
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == 'media.barney.crap-java') {
+                useModule("media.barney:crap-java-gradle-plugin:${requested.version}")
+            }
+        }
+    }
+
     repositories {
         mavenLocal()
         if (githubPackagesToken != null) {
             maven {
-                url = uri('https://maven.pkg.github.com/fabian-barney/crap4java')
+                url = uri('https://maven.pkg.github.com/fabian-barney/crap-java')
                 credentials {
                     username = githubPackagesUser
                     password = githubPackagesToken


### PR DESCRIPTION
## Summary
- switch the repo from `crap4java` to the released `crap-java` `0.2.0` Gradle integration
- rename the local gate command from `crap4javaCheck` to `crap-java-check` across the build, README, and workflow
- map the Gradle plugin id directly to the published `media.barney:crap-java-gradle-plugin` module in `settings.gradle`

## Testing
- `./gradlew check`
- `./gradlew crap-java-check`
- `./gradlew qualityGate`

Closes #12