### PR TITLE
Rename Java package and Gradle coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Provider ids and model ids are represented in code as typed value objects
 
 ## Build and Render
 
+The project coordinates are `media.barney:ai-agents`.
+
 Use the Gradle wrapper:
 
 ```bash

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'org.springframework.boot' version '3.5.13'
 }
 
-group = 'dev.fabianbarney.aiagents'
+group = 'media.barney'
 version = '0.1.0-SNAPSHOT'
 def lombokVersion = '1.18.44'
 def jacocoVersion = '0.8.13'
@@ -16,6 +16,10 @@ def nullawayVersion = '0.13.1'
 
 repositories {
     mavenCentral()
+}
+
+base {
+    archivesName = 'ai-agents'
 }
 
 java {
@@ -72,7 +76,7 @@ tasks.withType(JavaCompile).configureEach {
     ])
     options.errorprone {
         check('NullAway', net.ltgt.gradle.errorprone.CheckSeverity.ERROR)
-        option('NullAway:AnnotatedPackages', 'dev.fabianbarney.aiagents')
+        option('NullAway:AnnotatedPackages', 'media.barney.ai.agent')
     }
 }
 
@@ -82,7 +86,7 @@ tasks.register('renderAgents', JavaExec) {
     group = 'application'
     description = 'Render canonical agent definitions into target-specific artifacts.'
     classpath = sourceSets.main.runtimeClasspath
-    mainClass = 'dev.fabianbarney.aiagents.catalog.AgentCatalogApplication'
+    mainClass = 'media.barney.ai.agent.catalog.AgentCatalogApplication'
     args(
         "--catalog.input=${layout.projectDirectory.dir('agents').asFile.absolutePath}",
         "--catalog.output=${renderedOutputDir.get().asFile.absolutePath}"

--- a/src/main/java/media/barney/ai/agent/catalog/AgentCatalogApplication.java
+++ b/src/main/java/media/barney/ai/agent/catalog/AgentCatalogApplication.java
@@ -1,4 +1,4 @@
-package dev.fabianbarney.aiagents.catalog;
+package media.barney.ai.agent.catalog;
 
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;

--- a/src/main/java/media/barney/ai/agent/catalog/AgentCatalogService.java
+++ b/src/main/java/media/barney/ai/agent/catalog/AgentCatalogService.java
@@ -1,4 +1,4 @@
-package dev.fabianbarney.aiagents.catalog;
+package media.barney.ai.agent.catalog;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/media/barney/ai/agent/catalog/AgentDefinition.java
+++ b/src/main/java/media/barney/ai/agent/catalog/AgentDefinition.java
@@ -1,4 +1,4 @@
-package dev.fabianbarney.aiagents.catalog;
+package media.barney.ai.agent.catalog;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/media/barney/ai/agent/catalog/AgentDefinitionLoader.java
+++ b/src/main/java/media/barney/ai/agent/catalog/AgentDefinitionLoader.java
@@ -1,4 +1,4 @@
-package dev.fabianbarney.aiagents.catalog;
+package media.barney.ai.agent.catalog;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/main/java/media/barney/ai/agent/catalog/CatalogProperties.java
+++ b/src/main/java/media/barney/ai/agent/catalog/CatalogProperties.java
@@ -1,4 +1,4 @@
-package dev.fabianbarney.aiagents.catalog;
+package media.barney.ai.agent.catalog;
 
 import jakarta.validation.constraints.NotNull;
 import org.springframework.boot.context.properties.ConfigurationProperties;

--- a/src/main/java/media/barney/ai/agent/catalog/CatalogRunner.java
+++ b/src/main/java/media/barney/ai/agent/catalog/CatalogRunner.java
@@ -1,4 +1,4 @@
-package dev.fabianbarney.aiagents.catalog;
+package media.barney.ai.agent.catalog;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.ApplicationArguments;

--- a/src/main/java/media/barney/ai/agent/catalog/ClaudeRenderer.java
+++ b/src/main/java/media/barney/ai/agent/catalog/ClaudeRenderer.java
@@ -1,4 +1,4 @@
-package dev.fabianbarney.aiagents.catalog;
+package media.barney.ai.agent.catalog;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;

--- a/src/main/java/media/barney/ai/agent/catalog/CodexRenderer.java
+++ b/src/main/java/media/barney/ai/agent/catalog/CodexRenderer.java
@@ -1,4 +1,4 @@
-package dev.fabianbarney.aiagents.catalog;
+package media.barney.ai.agent.catalog;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;

--- a/src/main/java/media/barney/ai/agent/catalog/CopilotRenderer.java
+++ b/src/main/java/media/barney/ai/agent/catalog/CopilotRenderer.java
@@ -1,4 +1,4 @@
-package dev.fabianbarney.aiagents.catalog;
+package media.barney.ai.agent.catalog;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;

--- a/src/main/java/media/barney/ai/agent/catalog/ModelId.java
+++ b/src/main/java/media/barney/ai/agent/catalog/ModelId.java
@@ -1,4 +1,4 @@
-package dev.fabianbarney.aiagents.catalog;
+package media.barney.ai.agent.catalog;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/src/main/java/media/barney/ai/agent/catalog/PlatformOverrides.java
+++ b/src/main/java/media/barney/ai/agent/catalog/PlatformOverrides.java
@@ -1,4 +1,4 @@
-package dev.fabianbarney.aiagents.catalog;
+package media.barney.ai.agent.catalog;
 
 import jakarta.validation.Valid;
 import org.jspecify.annotations.Nullable;

--- a/src/main/java/media/barney/ai/agent/catalog/PreferredModel.java
+++ b/src/main/java/media/barney/ai/agent/catalog/PreferredModel.java
@@ -1,4 +1,4 @@
-package dev.fabianbarney.aiagents.catalog;
+package media.barney.ai.agent.catalog;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/media/barney/ai/agent/catalog/ProviderId.java
+++ b/src/main/java/media/barney/ai/agent/catalog/ProviderId.java
@@ -1,4 +1,4 @@
-package dev.fabianbarney.aiagents.catalog;
+package media.barney.ai.agent.catalog;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/src/main/java/media/barney/ai/agent/catalog/Renderer.java
+++ b/src/main/java/media/barney/ai/agent/catalog/Renderer.java
@@ -1,4 +1,4 @@
-package dev.fabianbarney.aiagents.catalog;
+package media.barney.ai.agent.catalog;
 
 import org.jspecify.annotations.Nullable;
 

--- a/src/main/java/media/barney/ai/agent/catalog/RendererProperties.java
+++ b/src/main/java/media/barney/ai/agent/catalog/RendererProperties.java
@@ -1,4 +1,4 @@
-package dev.fabianbarney.aiagents.catalog;
+package media.barney.ai.agent.catalog;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 

--- a/src/main/java/media/barney/ai/agent/catalog/RendererPropertyConverters.java
+++ b/src/main/java/media/barney/ai/agent/catalog/RendererPropertyConverters.java
@@ -1,4 +1,4 @@
-package dev.fabianbarney.aiagents.catalog;
+package media.barney.ai.agent.catalog;
 
 import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
 import org.springframework.core.convert.converter.Converter;

--- a/src/main/java/media/barney/ai/agent/catalog/package-info.java
+++ b/src/main/java/media/barney/ai/agent/catalog/package-info.java
@@ -1,4 +1,4 @@
 @NullMarked
-package dev.fabianbarney.aiagents.catalog;
+package media.barney.ai.agent.catalog;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/test/java/media/barney/ai/agent/catalog/AgentDefinitionLoaderTest.java
+++ b/src/test/java/media/barney/ai/agent/catalog/AgentDefinitionLoaderTest.java
@@ -1,4 +1,4 @@
-package dev.fabianbarney.aiagents.catalog;
+package media.barney.ai.agent.catalog;
 
 import jakarta.validation.Validation;
 import org.junit.jupiter.api.Test;
@@ -11,7 +11,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static dev.fabianbarney.aiagents.catalog.TestAssertions.assertMessageContains;
+import static media.barney.ai.agent.catalog.TestAssertions.assertMessageContains;
 
 class AgentDefinitionLoaderTest {
 

--- a/src/test/java/media/barney/ai/agent/catalog/ModelSelectionTest.java
+++ b/src/test/java/media/barney/ai/agent/catalog/ModelSelectionTest.java
@@ -1,4 +1,4 @@
-package dev.fabianbarney.aiagents.catalog;
+package media.barney.ai.agent.catalog;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/media/barney/ai/agent/catalog/RendererIntegrationTest.java
+++ b/src/test/java/media/barney/ai/agent/catalog/RendererIntegrationTest.java
@@ -1,4 +1,4 @@
-package dev.fabianbarney.aiagents.catalog;
+package media.barney.ai.agent.catalog;
 
 import jakarta.validation.Validation;
 import org.junit.jupiter.api.Test;
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static dev.fabianbarney.aiagents.catalog.TestAssertions.assertMessageContains;
+import static media.barney.ai.agent.catalog.TestAssertions.assertMessageContains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/src/test/java/media/barney/ai/agent/catalog/TestAssertions.java
+++ b/src/test/java/media/barney/ai/agent/catalog/TestAssertions.java
@@ -1,4 +1,4 @@
-package dev.fabianbarney.aiagents.catalog;
+package media.barney.ai.agent.catalog;
 
 import org.jspecify.annotations.Nullable;
 

--- a/src/test/java/media/barney/ai/agent/catalog/package-info.java
+++ b/src/test/java/media/barney/ai/agent/catalog/package-info.java
@@ -1,4 +1,4 @@
 @NullMarked
-package dev.fabianbarney.aiagents.catalog;
+package media.barney.ai.agent.catalog;
 
 import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
﻿Closes #17

## Implementation Summary
- Scope: rename the Java base package from `dev.fabianbarney.aiagents` to `media.barney.ai.agent` and align the build coordinates to `media.barney:ai-agents`.
- Key changes:
  - moved production and test sources into `media.barney.ai.agent.catalog`
  - updated the Gradle `group`, explicit archive name, NullAway annotated package root, and Spring Boot `mainClass`
  - updated the README to document the public coordinates
- Non-goals:
  - changing the repository name, canonical agent schema, or agent YAML ids

## Review Focus
- Generated/copied files and standard imports that can be skimmed:
  - package declaration rewrites across the moved Java source tree
- Non-obvious code paths and rationale:
  - `build.gradle` keeps `rootProject.name` unchanged but now sets `group = 'media.barney'` and `base.archivesName = 'ai-agents'` so published coordinates remain `media.barney:ai-agents` while the Java namespace becomes `media.barney.ai.agent`

## Validation
- Tests executed:
  - `./gradlew.bat test`
  - `./gradlew.bat check`
  - `./gradlew.bat qualityGate`
- Manual checks:
  - confirmed tracked-file search no longer finds `dev.fabianbarney.aiagents`
- Residual risks:
  - none beyond normal namespace-change risk already covered by the compile/test/gate runs
