### PR TITLE
Add cognitive-java quality gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,3 +50,24 @@ jobs:
 
       - name: Run crap-java gate
         run: ./gradlew crap-java-check
+
+  cognitive-java-gate:
+    name: cognitive-java Gate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: gradle
+
+      - name: Ensure Gradle wrapper is executable
+        run: chmod +x ./gradlew
+
+      - name: Run cognitive-java gate
+        run: ./gradlew cognitive-java-check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Run Gradle check
-        run: ./gradlew check
+        run: ./gradlew check -x cognitive-java-check
 
   crap-java-gate:
     name: crap-java Gate

--- a/README.md
+++ b/README.md
@@ -54,14 +54,17 @@ Use the Gradle wrapper:
 ```bash
 ./gradlew check
 ./gradlew crap-java-check
+./gradlew cognitive-java-check
 ./gradlew qualityGate
 ./gradlew renderAgents
 ```
 
 `./gradlew crap-java-check` runs the shared `media.barney.crap-java` `0.3.2`
-gate against the repository's production Java sources. `./gradlew qualityGate`
-is the repo-local convenience entrypoint that runs `check` plus
-`crap-java-check`.
+gate against the repository's production Java sources. `./gradlew
+cognitive-java-check` runs the shared `media.barney.cognitive-java` `0.3.0`
+gate. `./gradlew check` now includes the cognitive gate, and `./gradlew
+qualityGate` remains the repo-local convenience entrypoint that runs `check`
+plus the dedicated `crap-java-check` and `cognitive-java-check` tasks.
 
 Gradle resolves the shared `crap-java` plugin from published artifacts using
 `mavenCentral()` first and `gradlePluginPortal()` second. No committed

--- a/README.md
+++ b/README.md
@@ -60,16 +60,16 @@ Use the Gradle wrapper:
 ```
 
 `./gradlew crap-java-check` runs the shared `media.barney.crap-java` `0.3.2`
-gate against the repository's production Java sources. `./gradlew
-cognitive-java-check` runs the shared `media.barney.cognitive-java` `0.3.0`
-gate. `./gradlew check` now includes the cognitive gate, and `./gradlew
-qualityGate` remains the repo-local convenience entrypoint that runs `check`
-plus the dedicated `crap-java-check` and `cognitive-java-check` tasks.
+gate against the repository's production Java sources. `./gradlew cognitive-java-check`
+runs the shared `media.barney.cognitive-java` `0.3.0` gate. `./gradlew check`
+now includes the cognitive gate, and `./gradlew qualityGate` remains the
+repo-local convenience entrypoint that runs `check` plus the dedicated
+`crap-java-check` and `cognitive-java-check` tasks.
 
-Gradle resolves the shared `crap-java` plugin from published artifacts using
-`mavenCentral()` first and `gradlePluginPortal()` second. No committed
-custom package-host configuration, local `mavenLocal()` fallback, or extra
-credentials are required for the shared gate.
+Gradle resolves the shared `crap-java` and `cognitive-java` plugins from
+published artifacts using `mavenCentral()` first and `gradlePluginPortal()`
+second. No committed custom package-host configuration, local `mavenLocal()`
+fallback, or extra credentials are required for the shared gates.
 
 Renderer output artifacts from `./gradlew renderAgents` are written under `build/rendered/`:
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'jacoco'
     id 'media.barney.crap-java' version '0.3.2'
+    id 'media.barney.cognitive-java' version '0.3.0'
     id 'net.ltgt.errorprone' version '5.1.0'
     id 'org.springframework.boot' version '3.5.13'
 }
@@ -109,9 +110,9 @@ tasks.named('jacocoTestReport') {
 tasks.register('qualityGate') {
     group = 'verification'
     description = 'Run the repository quality gate tasks.'
-    dependsOn(tasks.named('check'), tasks.named('crap-java-check'))
+    dependsOn(tasks.named('check'), tasks.named('crap-java-check'), tasks.named('cognitive-java-check'))
 }
 
 tasks.named('check') {
-    dependsOn(tasks.named('renderAgents'))
+    dependsOn(tasks.named('renderAgents'), tasks.named('cognitive-java-check'))
 }


### PR DESCRIPTION
## Summary
- add the published cognitive-java Gradle plugin
- wire check and qualityGate to cognitive-java-check
- add a dedicated cognitive-java Gate GitHub Actions job and document the local commands

Closes #19