### PR TITLE
Update Spring Boot and Java tooling

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -12,8 +12,8 @@ jobs:
   markdownlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: DavidAnson/markdownlint-cli2-action@b4c9feab76d8025d1e83c653fa3990936df0e6c8
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd
         with:
           globs: |
             **/*.md
@@ -23,7 +23,7 @@ jobs:
   linkcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: lycheeverse/lychee-action@7cd0af4c74a61395d455af97419279d86aafaede
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411
         with:
-          args: --no-progress --verbose --exclude-mail "**/*.md"
+          args: --no-progress --verbose "**/*.md"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up JDK 25
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
           distribution: temurin
           java-version: "25"
@@ -36,10 +36,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up JDK 25
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
           distribution: temurin
           java-version: "25"
@@ -57,10 +57,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up JDK 25
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
           distribution: temurin
           java-version: "25"

--- a/ai/AI-RULES/.github/workflows/docs-check.yml
+++ b/ai/AI-RULES/.github/workflows/docs-check.yml
@@ -12,8 +12,8 @@ jobs:
   markdownlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: DavidAnson/markdownlint-cli2-action@b4c9feab76d8025d1e83c653fa3990936df0e6c8
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd
         with:
           globs: |
             **/*.md
@@ -23,7 +23,7 @@ jobs:
   linkcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: lycheeverse/lychee-action@7cd0af4c74a61395d455af97419279d86aafaede
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411
         with:
-          args: --no-progress --verbose --exclude-mail "**/*.md"
+          args: --no-progress --verbose "**/*.md"

--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,19 @@
 plugins {
     id 'java'
     id 'jacoco'
-    id 'media.barney.crap-java' version '0.3.2'
+    id 'media.barney.crap-java' version '0.4.1'
     id 'media.barney.cognitive-java' version '0.4.0'
     id 'net.ltgt.errorprone' version '5.1.0'
-    id 'org.springframework.boot' version '3.5.13'
+    id 'org.springframework.boot' version '4.0.6'
 }
 
 group = 'media.barney'
 version = '0.1.0-SNAPSHOT'
 def lombokVersion = '1.18.44'
-def jacocoVersion = '0.8.13'
+def jacocoVersion = '0.8.14'
 def jspecifyVersion = '1.0.0'
-def errorproneVersion = '2.48.0'
-def nullawayVersion = '0.13.1'
+def errorproneVersion = '2.49.0'
+def nullawayVersion = '0.13.4'
 
 repositories {
     mavenCentral()
@@ -33,9 +33,9 @@ jacoco {
 }
 
 dependencies {
-    implementation platform('org.springframework.boot:spring-boot-dependencies:3.5.13')
-    annotationProcessor platform('org.springframework.boot:spring-boot-dependencies:3.5.13')
-    testImplementation platform('org.springframework.boot:spring-boot-dependencies:3.5.13')
+    implementation platform('org.springframework.boot:spring-boot-dependencies:4.0.6')
+    annotationProcessor platform('org.springframework.boot:spring-boot-dependencies:4.0.6')
+    testImplementation platform('org.springframework.boot:spring-boot-dependencies:4.0.6')
 
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-validation'


### PR DESCRIPTION
## Summary
- update Spring Boot from 3.5.13 to 4.0.6 and keep Spring-managed dependencies inside the Boot BOM
- update Java quality tooling versions for Jacoco, Error Prone, NullAway, and the crap-java Gradle plugin
- update pinned GitHub Actions SHAs for checkout, setup-java, markdownlint-cli2-action, and lychee-action
- keep the Java 25 runtime/compiler baseline unchanged
- remove lychee's obsolete `--exclude-mail` argument; current lychee keeps email checks opt-in via `--include-mail`, and CI linkcheck passes without checking placeholder email addresses

## Validation
- `./gradlew.bat check -x cognitive-java-check`
- `./gradlew.bat crap-java-check`
- `./gradlew.bat cognitive-java-check`
- docs workflow YAML parse via Python `yaml.safe_load`

Closes #23