### PR TITLE
[codex] Upgrade crap-java to 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Use the Gradle wrapper:
 ./gradlew renderAgents
 ```
 
-`./gradlew crap-java-check` runs the shared `media.barney.crap-java` `0.3.2`
+`./gradlew crap-java-check` runs the shared `media.barney.crap-java` `0.5.0`
 gate against the repository's production Java sources. `./gradlew cognitive-java-check`
 runs the shared `media.barney.cognitive-java` `0.4.0` gate. `./gradlew check`
 now includes the cognitive gate, and `./gradlew qualityGate` remains the

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'jacoco'
-    id 'media.barney.crap-java' version '0.4.1'
+    id 'media.barney.crap-java' version '0.5.0'
     id 'media.barney.cognitive-java' version '0.4.0'
     id 'net.ltgt.errorprone' version '5.1.0'
     id 'org.springframework.boot' version '4.0.6'


### PR DESCRIPTION
Closes #25

## What changed
- bump the shared `media.barney.crap-java` Gradle plugin from `0.4.1` to `0.5.0`
- align the README gate version reference with the build configuration

## Validation
- `./gradlew.bat check -x cognitive-java-check`
- `./gradlew.bat crap-java-check`
- `./gradlew.bat cognitive-java-check`