### PR TITLE
Update Lombok dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 group = 'media.barney'
 version = '0.1.0-SNAPSHOT'
-def lombokVersion = '1.18.44'
+def lombokVersion = '1.18.46'
 def jacocoVersion = '0.8.14'
 def jspecifyVersion = '1.0.0'
 def errorproneVersion = '2.49.0'


### PR DESCRIPTION
## Summary
- update Lombok from `1.18.44` to `1.18.46`
- keep Java 25, Gradle 9.4.1, Spring Boot 4.0.6, and existing workflow action pins unchanged

## Validation
- `./gradlew check -x cognitive-java-check`
- `./gradlew crap-java-check`
- `./gradlew cognitive-java-check`

Note: Java 25 still emits an existing Lombok `sun.misc.Unsafe` deprecation warning, but all validation commands completed successfully.

Closes #27