### PR TITLE
Fix #29 align CI stage families and quality gates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
           path: build
 
       - name: Run unit tests
-        run: ./gradlew --build-cache test jacocoTestReport
+        run: ./gradlew --build-cache renderAgents test jacocoTestReport
 
       - name: Upload verified build outputs
         uses: actions/upload-artifact@v7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,7 +101,7 @@ jobs:
           path: build
 
       - name: Package application
-        run: ./gradlew --build-cache --offline bootJar
+        run: ./gradlew --build-cache bootJar
 
   quality-crap-ai-agents:
     name: verify / quality-crap-ai-agents
@@ -131,7 +131,7 @@ jobs:
           path: build
 
       - name: Run crap-java gate
-        run: ./gradlew --build-cache --offline crap-java-check
+        run: ./gradlew --build-cache crap-java-check
 
   quality-cognitive-ai-agents:
     name: verify / quality-cognitive-ai-agents
@@ -161,4 +161,4 @@ jobs:
           path: build
 
       - name: Run cognitive-java gate
-        run: ./gradlew --build-cache --offline cognitive-java-check
+        run: ./gradlew --build-cache cognitive-java-check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
 
       - name: Set up JDK 25
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "25"
@@ -31,7 +31,7 @@ jobs:
         run: ./gradlew --build-cache assemble
 
       - name: Upload build outputs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-output
           path: build
@@ -45,10 +45,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
 
       - name: Set up JDK 25
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "25"
@@ -58,7 +58,7 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Download build outputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-output
           path: build
@@ -67,7 +67,7 @@ jobs:
         run: ./gradlew --build-cache test jacocoTestReport
 
       - name: Upload verified build outputs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: verified-build-output
           path: build
@@ -82,10 +82,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
 
       - name: Set up JDK 25
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "25"
@@ -95,7 +95,7 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Download verified build outputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: verified-build-output
           path: build
@@ -112,10 +112,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
 
       - name: Set up JDK 25
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "25"
@@ -125,7 +125,7 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Download verified build outputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: verified-build-output
           path: build
@@ -142,10 +142,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v6
 
       - name: Set up JDK 25
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "25"
@@ -155,7 +155,7 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Download verified build outputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: verified-build-output
           path: build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,8 @@ permissions:
   contents: read
 
 jobs:
-  gradle-check:
-    name: Gradle Check
+  build:
+    name: build
     runs-on: ubuntu-latest
 
     steps:
@@ -27,12 +27,21 @@ jobs:
       - name: Ensure Gradle wrapper is executable
         run: chmod +x ./gradlew
 
-      - name: Run Gradle check
-        run: ./gradlew check -x cognitive-java-check
+      - name: Build
+        run: ./gradlew --build-cache assemble
 
-  crap-java-gate:
-    name: crap-java Gate
+      - name: Upload build outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-output
+          path: build
+          if-no-files-found: error
+
+  test-unit:
+    name: test / unit
     runs-on: ubuntu-latest
+    needs:
+      - build
 
     steps:
       - name: Checkout
@@ -47,13 +56,89 @@ jobs:
 
       - name: Ensure Gradle wrapper is executable
         run: chmod +x ./gradlew
+
+      - name: Download build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output
+          path: build
+
+      - name: Run unit tests
+        run: ./gradlew --build-cache test jacocoTestReport
+
+      - name: Upload verified build outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: verified-build-output
+          path: build
+          if-no-files-found: error
+
+  package:
+    name: package
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - test-unit
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: gradle
+
+      - name: Ensure Gradle wrapper is executable
+        run: chmod +x ./gradlew
+
+      - name: Download verified build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: verified-build-output
+          path: build
+
+      - name: Package application
+        run: ./gradlew --build-cache --offline bootJar
+
+  quality-crap-ai-agents:
+    name: verify / quality-crap-ai-agents
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - test-unit
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: gradle
+
+      - name: Ensure Gradle wrapper is executable
+        run: chmod +x ./gradlew
+
+      - name: Download verified build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: verified-build-output
+          path: build
 
       - name: Run crap-java gate
-        run: ./gradlew crap-java-check
+        run: ./gradlew --build-cache --offline crap-java-check
 
-  cognitive-java-gate:
-    name: cognitive-java Gate
+  quality-cognitive-ai-agents:
+    name: verify / quality-cognitive-ai-agents
     runs-on: ubuntu-latest
+    needs:
+      - build
+      - test-unit
 
     steps:
       - name: Checkout
@@ -69,5 +154,11 @@ jobs:
       - name: Ensure Gradle wrapper is executable
         run: chmod +x ./gradlew
 
+      - name: Download verified build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: verified-build-output
+          path: build
+
       - name: Run cognitive-java gate
-        run: ./gradlew cognitive-java-check
+        run: ./gradlew --build-cache --offline cognitive-java-check


### PR DESCRIPTION
## Summary
- reshape the Gradle workflow to stage-family job names
- split the Java quality gates into dedicated jobs
- reuse upstream build artifacts across downstream checks

## Validation
- ran assemble, test, bootJar, CRAP, and cognitive Gradle commands locally

Closes #29