### PR TITLE
chore(deps): update compatible Gradle quality plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     id 'java'
     id 'jacoco'
-    id 'media.barney.crap-java' version '0.5.0'
-    id 'media.barney.cognitive-java' version '0.4.0'
+    id 'media.barney.crap-java' version '0.6.0'
+    id 'media.barney.cognitive-java' version '0.5.1'
     id 'net.ltgt.errorprone' version '5.1.0'
     id 'org.springframework.boot' version '4.0.6'
 }


### PR DESCRIPTION
Closes #32

## Summary

- Updates Gradle quality plugin versions to compatible stable releases.
- Preserves Java 25.

## Validation

- .\\gradlew.bat check; .\\gradlew.bat qualityGate.

## Review Notes

- Dependency-only change; no public runtime floor was raised.
- Latest-compatible versions were selected over latest-absolute releases when framework or runtime constraints required it.